### PR TITLE
Support for typescript users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 .nyc_output
 coverage
+dist
+@types

--- a/package-lock.json
+++ b/package-lock.json
@@ -434,6 +434,12 @@
         "defer-to-connect": "^1.0.1"
       }
     },
+    "@tsconfig/node12": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.7.tgz",
+      "integrity": "sha512-dgasobK/Y0wVMswcipr3k0HpevxFJLijN03A8mYfEPvWvOs14v0ZlYTR4kIgMx8g4+fTyTFv8/jLCIfRqLDJ4A==",
+      "dev": true
+    },
     "@types/json-schema": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
@@ -5301,6 +5307,12 @@
       "requires": {
         "is-typedarray": "^1.0.0"
       }
+    },
+    "typescript": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+      "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
+      "dev": true
     },
     "unique-string": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,13 @@
   "name": "@r2d2bzh/broker-autobot",
   "version": "0.0.0",
   "description": "self-configuring robotic lifeform to manage centrally the configuration of all Moleculer brokers",
-  "main": "src",
-  "types": "./dist/typings.d.ts",
+  "main": "src/broker-autobot.js",
+  "types": "./@types",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "types": "tsc",
     "test": "nyc ava",
     "lint": "eslint ."
   },
@@ -40,8 +41,10 @@
     "uuid": "^8.3.1",
     "@r2d2bzh/eslint-config": "0.0.0",
     "@r2d2bzh/js-rules": "0.0.0",
+    "@tsconfig/node12": "^1.0.7",
     "@types/node": "^14.14.10",
     "ava": "^3.13.0",
-    "nyc": "^15.1.0"
+    "nyc": "^15.1.0",
+    "typescript": "^4.1.2"
   }
 }

--- a/src/broker-autobot.js
+++ b/src/broker-autobot.js
@@ -36,6 +36,14 @@ const onConfigUpdate = ({ stop, start, log, updateWindowSize }) => async (ctx) =
 
 /**
  * @param {autobotOptions} AutobotOptions
+ * @returns {Promise<{
+ *  call: () => Promise<any>,
+ *  on: Function,
+ *  start: (options: { initial?: any, current?: any, overload?: any }) => Promise<any>,
+ *  stop: () => Promise<void>,
+ *  waitForServices: (services: schemaFactory[]) => Promise<void>,
+ *  nodeID: () => string}>
+ * }
  */
 module.exports = ({
   initialSettings = {},
@@ -62,6 +70,9 @@ module.exports = ({
     schemaFactories,
   });
 
+  /**
+   * @param {{ initial?: any; current?: any; overload?: any; }} currentSettings
+   */
   const start = async (currentSettings) => {
     if (!currentSettings && settingsRetrievalAction.serviceName) {
       await brokerRevolver.start(settings);
@@ -88,9 +99,11 @@ module.exports = ({
     })
   );
 
+  // @ts-ignore
   return {
     ...exposedBrokerResolverMethods,
     start,
+    // @ts-ignore
     on: (...args) => brokerRevolver.on(...args),
   };
 };

--- a/src/broker-revolver.js
+++ b/src/broker-revolver.js
@@ -5,7 +5,7 @@ const newBrokerShell = require('./broker-shell');
 const throttle = require('lodash.throttle');
 
 /**
- * @param {settingsUpdateEvent} settingsUpdateEvent
+ * @param {newSettingsUpdateEvent} settingsUpdateEvent
  * @param {() => import('moleculer').LoggerInstance} log
  * @param {Function} nodeID
  * @param {Function} emit

--- a/src/types.js
+++ b/src/types.js
@@ -24,6 +24,8 @@
 
 /** @typedef {{ name?: string; throttling?: number; predicate?: (param?: any) => boolean }} settingsUpdateEvent */
 
+/** @typedef {{ name: string; throttling?: number; predicate?: (param?: any) => boolean }} newSettingsUpdateEvent */
+
 /** @typedef { () => import('moleculer').ServiceSchema} schemaFactory */
 
 /**

--- a/test/retrieve-config.js
+++ b/test/retrieve-config.js
@@ -1,7 +1,7 @@
 const test = require('ava');
 const { ServiceBroker } = require('moleculer');
 const { v4: uuid } = require('uuid');
-const brokerAutobot = require('../src');
+const brokerAutobot = require('../src/broker-autobot');
 const { describeConfigFactory } = require('./helpers/utils');
 const middleware = require('./helpers/middleware');
 

--- a/test/simple-config.js
+++ b/test/simple-config.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const { v4: uuid } = require('uuid');
-const brokerAutobot = require('../src');
+const brokerAutobot = require('../src/broker-autobot');
 const middleware = require('./helpers/middleware');
 const { describeConfigFactory } = require('./helpers/utils');
 

--- a/test/update-config.js
+++ b/test/update-config.js
@@ -2,7 +2,7 @@
 const test = require('ava');
 const { ServiceBroker } = require('moleculer');
 const { v4: uuid } = require('uuid');
-const brokerAutobot = require('../src');
+const brokerAutobot = require('../src/broker-autobot');
 const middleware = require('./helpers/middleware');
 const { describeConfigFactory } = require('./helpers/utils');
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,11 @@
 {
+  "extends": "@tsconfig/node12/tsconfig.json",
   "compilerOptions": {
-    "module": "ES2020",
-    "moduleResolution": "Node",
-    "lib": ["ES2020"],
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,
-    "checkJs": true,
-    "outFile": "dist/typings.d.ts"
+    "outFile": "@types/index.d.ts",
+    "noImplicitAny": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
Typescript users might want types to be generated.
This PR allows types generation.
Types must be pushed to npm as well.

#1 is needed before this one